### PR TITLE
Fix en_quote fences and add regression test

### DIFF
--- a/md_post_processing.py
+++ b/md_post_processing.py
@@ -172,15 +172,14 @@ def mark_english_blocks(md_text: str, scope: str = "anywhere") -> str:
             text = text_for_detection(block, is_quote=True)
             if _looks_english_only(text) and not (FOOTNOTE_DEF_RE.search(text) or FOOTNOTE_REF_RE.search(text) or URL_RE.search(text)):
                 indent = _common_indent(block)
-                out.append(f'{indent}::{{}}')                  # harmless spacer for readability
-                out.append(f'{indent}::{{}}')                  # (keeps a blank line after attrs)
-                out.append(f'{indent}::{{}}')                  # (these empty colons are ignored)
-                out.append(f'{indent}:::{ { "div" } }'.replace(' ', ''))  # -> ':::{div}'
-                out.append(f'{indent}:class: en_quote')
-                out.append(f'{indent}:dir: ltr')
-                out.append('')
+                if out and out[-1] is not None and out[-1].strip():
+                    out.append(indent if indent else "")
+                out.append(f"{indent}:::{{div}}")
+                out.append(f"{indent}:class: en_quote")
+                out.append(f"{indent}:dir: ltr")
+                out.append(indent if indent else "")
                 out.extend(block)                               # keep the original '>' lines
-                out.append(f'{indent}:::')
+                out.append(f"{indent}:::")
             else:
                 out.extend(block)
             i = j
@@ -196,12 +195,14 @@ def mark_english_blocks(md_text: str, scope: str = "anywhere") -> str:
             text = text_for_detection(block, is_quote=False)
             if _looks_english_only(text) and not (FOOTNOTE_DEF_RE.search(text) or FOOTNOTE_REF_RE.search(text) or URL_RE.search(text)):
                 indent = _common_indent(block)
-                out.append(f'{indent}:::{ { "div" } }'.replace(' ', ''))
-                out.append(f'{indent}:class: en_quote')
-                out.append(f'{indent}:dir: ltr')
-                out.append('')
+                if out and out[-1] is not None and out[-1].strip():
+                    out.append(indent if indent else "")
+                out.append(f"{indent}:::{{div}}")
+                out.append(f"{indent}:class: en_quote")
+                out.append(f"{indent}:dir: ltr")
+                out.append(indent if indent else "")
                 out.extend(block)
-                out.append(f'{indent}:::')
+                out.append(f"{indent}:::")
             else:
                 out.extend(block)
             i = j
@@ -246,9 +247,15 @@ def _fix_colon_en_quote_blocks(text: str) -> str:
     def _fix(m: re.Match) -> str:
         indent, payload = m.group(1), m.group(2)
         payload_fixed = _unescape_in_en_quote(payload)
-        return f"{indent}:::{ { 'div' } }".replace(' ', '') + \
-               f"\n{indent}:class: en_quote\n{indent}:dir: ltr\n\n" + \
-               payload_fixed + f"\n{indent}:::"
+        lines = [
+            f"{indent}:::{{div}}",
+            f"{indent}:class: en_quote",
+            f"{indent}:dir: ltr",
+            indent if indent else "",
+        ]
+        lines.extend(payload_fixed.splitlines())
+        lines.append(f"{indent}:::")
+        return "\n".join(lines)
     return _COLON_EN_QUOTE_BLOCK_RE.sub(_fix, text)
 
 def normalize_pandoc_attrs(md_path: Path):

--- a/tests/test_mark_english_blocks.py
+++ b/tests/test_mark_english_blocks.py
@@ -1,0 +1,71 @@
+import sys
+import textwrap
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from md_post_processing import mark_english_blocks
+
+
+def test_mark_english_blocks_emits_valid_colon_fences():
+    source = textwrap.dedent(
+        """
+        פתיח בעברית בלבד.
+
+        An English paragraph that should be wrapped.
+
+        > Energy is the only universal currency.
+        > One of its many forms must be transformed to get anything done.
+
+        - רשומה ברשימה
+          > This is an English quote inside a list.
+          > It should keep its indentation.
+
+        Another paragraph עם קצת Hebrew שלא אמור להיות עטוף.
+        """
+    ).strip("\n")
+
+    rendered = mark_english_blocks(source)
+
+    assert ":::{div}" in rendered
+    assert "::{{}}" not in rendered
+    assert "::: {" not in rendered
+
+    expected_paragraph = textwrap.dedent(
+        """
+        :::{div}
+        :class: en_quote
+        :dir: ltr
+
+        An English paragraph that should be wrapped.
+        :::
+        """
+    ).strip("\n")
+    assert expected_paragraph in rendered
+
+    expected_top_level = textwrap.dedent(
+        """
+        :::{div}
+        :class: en_quote
+        :dir: ltr
+
+        > Energy is the only universal currency.
+        > One of its many forms must be transformed to get anything done.
+        :::
+        """
+    ).strip("\n")
+    assert expected_top_level in rendered
+
+    lines = rendered.splitlines()
+    list_index = lines.index("- רשומה ברשימה")
+    assert lines[list_index + 1].strip() == ""
+    assert lines[list_index + 2] == "  :::{div}"
+    assert lines[list_index + 3] == "  :class: en_quote"
+    assert lines[list_index + 4] == "  :dir: ltr"
+    assert lines[list_index + 5].strip() == ""
+    assert lines[list_index + 6] == "  > This is an English quote inside a list."
+    assert lines[list_index + 7] == "  > It should keep its indentation."
+    assert lines[list_index + 8] == "  :::"
+
+    assert "Another paragraph" in rendered
+    assert "עם קצת Hebrew" in rendered


### PR DESCRIPTION
## Summary
- emit valid MyST colon fences for detected English paragraphs/quotes and keep indent-aware blank lines
- align colon-fence normalization with the new wrapper format so post-processing preserves `.en_quote` blocks
- add a regression test covering nested quotes and lists to ensure fences remain well-formed

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d2df5f1eec832ab2effc0714ca932b