### PR TITLE
Adjust quote styling and prune unused footnotes

### DIFF
--- a/_static/style.css
+++ b/_static/style.css
@@ -19,7 +19,7 @@ html[dir="rtl"] p, html[dir="rtl"] li {
 
 /* Shared “quote panel” look used for normal blockquotes and English quotes */
 blockquote,
-.en_quote blockquote {
+.en_quote {
   background: #f3f5f7;
   padding: 0.6rem 1rem;
   border-radius: 6px;
@@ -28,17 +28,30 @@ blockquote,
   margin: 1rem 0;
 }
 
-/* Remove extra spacing inside the English wrapper */
-.en_quote blockquote { margin: 0; }
-
 /* English epigraphs/quotes: force LTR and left alignment, isolate bidi */
 .en_quote {
   direction: ltr;
   unicode-bidi: isolate;
   text-align: left;
-  /* keep the wrapper itself visually neutral; the blockquote inside is styled */
   display: block;
-  margin: 1rem 0;
+}
+
+/* Hebrew blockquotes should align right by default */
+.bd-article blockquote {
+  direction: rtl;
+  text-align: right;
+  unicode-bidi: plaintext;
+}
+
+/* Remove nested chrome when MyST wraps a Markdown blockquote */
+.en_quote > blockquote {
+  background: none;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  direction: ltr;
+  text-align: left;
+  unicode-bidi: isolate;
 }
 
 /* Links long URLs wrap better inside quotes */
@@ -76,16 +89,16 @@ html[dir="rtl"] .figure .caption, html[dir="rtl"] figure figcaption {
 @media (max-width: 768px) { #search-results { margin: 10px; } }
 
 /* =============================================================================
-   Desktop (≥992px): right sidebar as a static column you can collapse
+   Desktop (≥992px): left sidebar as a static column you can collapse
 ============================================================================= */
 @media (min-width: 992px) {
   .bd-container__inner { display: flex; gap: var(--pst-horizontal-spacing, 2rem); }
-  .bd-main { order: 1; flex: 1 1 auto; }
-  #pst-primary-sidebar { order: 2; flex: 0 0 var(--bd-sidebar-primary-width, 18rem); }
+  .bd-main { order: 2; flex: 1 1 auto; }
+  #pst-primary-sidebar { order: 1; flex: 0 0 var(--bd-sidebar-primary-width, 18rem); }
 
   #pst-primary-sidebar { transition: transform .2s ease, width .2s ease; will-change: transform; }
   body.rtl-sidebar-collapsed #pst-primary-sidebar {
-    transform: translateX(100%);
+    transform: translateX(-100%);
     width: 0 !important; flex-basis: 0 !important;
     margin: 0 !important; padding: 0 !important; overflow: hidden !important;
   }
@@ -95,24 +108,28 @@ html[dir="rtl"] .figure .caption, html[dir="rtl"] figure figcaption {
 }
 
 /* =============================================================================
-   Mobile (<992px): use the dialog, slide from the RIGHT
+   Mobile (<992px): use the dialog, slide from the LEFT
 ============================================================================= */
 @media (max-width: 991.98px) {
   #pst-primary-sidebar { display: none !important; }
 
   dialog#pst-primary-sidebar-modal {
-    position: fixed; top: 0; right: 0; bottom: 0; left: auto;
+    position: fixed; top: 0; left: 0; bottom: 0; right: auto;
     margin: 0; padding: 0; width: min(84vw, 420px); max-width: 100%; height: 100%;
     border: 0; background: var(--bs-body-bg, #fff);
-    transform: translateX(100%); transition: transform .2s ease-out;
+    transform: translateX(-100%); transition: transform .2s ease-out;
   }
   dialog#pst-primary-sidebar-modal[open] { transform: none; }
-  dialog#pst-primary-sidebar-modal::backdrop { background: rgba(0,0,0,.45); }
+dialog#pst-primary-sidebar-modal::backdrop { background: rgba(0,0,0,.45); }
 }
 
 /* =============================================================================
    Typography
 ============================================================================= */
+.header-article-items { display: flex; }
+.header-article-items__start { order: 2; }
+.header-article-items__end { order: 1; }
+
 .bd-article p { text-align: justify; } /* don’t force lists; handled below */
 
 /* =============================================================================

--- a/book-pipeline.py
+++ b/book-pipeline.py
@@ -13,6 +13,7 @@ from md_post_processing import (
     promote_top_title_line_to_h1,
     normalize_md_file_headings,
     number_md_headings,
+    remove_unreferenced_footnotes_file,
 )
 from build_book import (
     _first_h1_title,
@@ -58,6 +59,7 @@ def generate_md_files(input_dir, output_dir, copy_raw=False):
         # If you ever want the old behavior, call: mark_english_blocks_file(md_output, scope="before_first_h1", mode="paragraphs_and_blockquotes")
         mark_english_blocks_file(md_output, scope="before_first_h1")
         normalize_pandoc_attrs(Path(md_output))
+        remove_unreferenced_footnotes_file(md_output)
 
         # Insert figures from the external assets directory into MyST figure blocks
         process_markdown_insert_figures(

--- a/md_post_processing.py
+++ b/md_post_processing.py
@@ -10,7 +10,9 @@ HEADING_RE = re.compile(r'^(#{1,6})\s+(.*)$')
 HEBREW_RE = re.compile(r'[\u0590-\u05FF]')          # Hebrew Unicode block
 LATIN_RE  = re.compile(r'[A-Za-z]')
 FOOTNOTE_DEF_RE = re.compile(r'^\s*\[\^[^\]]+\]:')   # [^1]:
+FOOTNOTE_DEF_CAPTURE_RE = re.compile(r'^\s*\[\^([^\]]+)\]:')
 FOOTNOTE_REF_RE = re.compile(r'\[\^[^\]]+\]')        # inline refs [^1]
+FOOTNOTE_REF_CAPTURE_RE = re.compile(r'\[\^([^\]]+)\](?!\s*:)')
 FIRST_NONBLANK_HEADING_FORMS = re.compile(r'^\s*(?:[*_]{1,3}\s*)?(.+?)(?:\s*[*_]{1,3})?\s*$')
 URL_RE = re.compile(r'(https?://|www\.)', re.IGNORECASE)
 
@@ -21,13 +23,13 @@ _HTML_EN_QUOTE_BLOCK_RE = re.compile(
 )
 
 # New MyST colon-fence wrapper for en_quote blocks
-# Captures: indent, header (opening + attrs), payload, and closing fence with same indent
+# Captures: indent, directive name, options, payload, and closing fence with same indent
 _COLON_EN_QUOTE_BLOCK_RE = re.compile(
-    r'(?ms)^([ \t]*):::\{div\}\s*\n'                                  # indent + :::{div}
-    r'(?:(?:[ \t]*:class:\s*en_quote\s*\n|[ \t]*:dir:\s*ltr\s*\n)){2}' # two lines containing class and dir (any order)
-    r'\n?'                                                             # optional spacer line
-    r'(.*?)'                                                           # payload (group 2)
-    r'\n\1:::\s*$'                                                     # closing fence at same indent
+    r'(?ms)^([ \t]*):::\{(?P<directive>div|container)\}\s*\n'  # indent + :::{div|container}
+    r'(?P<options>(?:[ \t]*:[^\n]+\n)*)'                        # option lines (if any)
+    r'\n?'                                                        # optional spacer line
+    r'(?P<body>.*?)'                                               # payload content
+    r'\n\1:::\s*$'                                              # closing fence at same indent
 )
 
 # --- Title promotion ---------------------------------------------------------
@@ -92,11 +94,10 @@ def _common_indent(block_lines: list[str]) -> str:
 
 def mark_english_blocks(md_text: str, scope: str = "anywhere") -> str:
     """
-    Wrap English-only blockquotes/paragraphs in a MyST div using colon-fences:
+    Wrap English-only blockquotes/paragraphs in a MyST container using colon-fences:
 
-        ::: {div}
+        ::: {container}
         :class: en_quote
-        :dir: ltr
 
         > ...
         :::
@@ -174,10 +175,10 @@ def mark_english_blocks(md_text: str, scope: str = "anywhere") -> str:
                 indent = _common_indent(block)
                 if out and out[-1] is not None and out[-1].strip():
                     out.append(indent if indent else "")
-                out.append(f"{indent}:::{{div}}")
+                out.append(f"{indent}:::{{container}}")
                 out.append(f"{indent}:class: en_quote")
-                out.append(f"{indent}:dir: ltr")
-                out.append(indent if indent else "")
+                if indent:
+                    out.append(indent)
                 out.extend(block)                               # keep the original '>' lines
                 out.append(f"{indent}:::")
             else:
@@ -197,10 +198,10 @@ def mark_english_blocks(md_text: str, scope: str = "anywhere") -> str:
                 indent = _common_indent(block)
                 if out and out[-1] is not None and out[-1].strip():
                     out.append(indent if indent else "")
-                out.append(f"{indent}:::{{div}}")
+                out.append(f"{indent}:::{{container}}")
                 out.append(f"{indent}:class: en_quote")
-                out.append(f"{indent}:dir: ltr")
-                out.append(indent if indent else "")
+                if indent:
+                    out.append(indent)
                 out.extend(block)
                 out.append(f"{indent}:::")
             else:
@@ -245,18 +246,75 @@ def _fix_html_en_quote_blocks(text: str) -> str:
 
 def _fix_colon_en_quote_blocks(text: str) -> str:
     def _fix(m: re.Match) -> str:
-        indent, payload = m.group(1), m.group(2)
-        payload_fixed = _unescape_in_en_quote(payload)
-        lines = [
-            f"{indent}:::{{div}}",
-            f"{indent}:class: en_quote",
-            f"{indent}:dir: ltr",
-            indent if indent else "",
-        ]
+        indent = m.group(1)
+        payload_fixed = _unescape_in_en_quote(m.group('body'))
+        lines = [f"{indent}:::{{container}}", f"{indent}:class: en_quote"]
+        if indent:
+            lines.append(indent)
         lines.extend(payload_fixed.splitlines())
         lines.append(f"{indent}:::")
         return "\n".join(lines)
     return _COLON_EN_QUOTE_BLOCK_RE.sub(_fix, text)
+
+
+def remove_unreferenced_footnotes(md_text: str) -> str:
+    """Strip footnote definitions that are never referenced in the document."""
+    if not FOOTNOTE_DEF_RE.search(md_text):
+        return md_text
+
+    lines = md_text.splitlines()
+    refs: set[str] = set()
+    for line in lines:
+        if FOOTNOTE_DEF_CAPTURE_RE.match(line):
+            continue
+        refs.update(m.group(1) for m in FOOTNOTE_REF_CAPTURE_RE.finditer(line))
+
+    cleaned: list[str] = []
+    i = 0
+
+    while i < len(lines):
+        line = lines[i]
+        m = FOOTNOTE_DEF_CAPTURE_RE.match(line)
+        if not m:
+            cleaned.append(line)
+            i += 1
+            continue
+
+        label = m.group(1)
+        block_start = i
+        i += 1
+        while i < len(lines):
+            nxt = lines[i]
+            if FOOTNOTE_DEF_CAPTURE_RE.match(nxt):
+                break
+            if nxt.startswith("    ") or nxt.startswith("\t"):
+                i += 1
+                continue
+            if not nxt.strip() and i + 1 < len(lines) and (
+                lines[i + 1].startswith("    ") or lines[i + 1].startswith("\t")
+            ):
+                i += 1
+                continue
+            break
+
+        if label in refs:
+            cleaned.extend(lines[block_start:i])
+        else:
+            while cleaned and not cleaned[-1].strip():
+                cleaned.pop()
+
+    result = "\n".join(cleaned)
+    if md_text.endswith("\n") and not result.endswith("\n"):
+        result += "\n"
+    return result
+
+
+def remove_unreferenced_footnotes_file(md_path: str | Path) -> None:
+    p = Path(md_path)
+    text = p.read_text(encoding="utf-8")
+    fixed = remove_unreferenced_footnotes(text)
+    if fixed != text:
+        p.write_text(fixed, encoding="utf-8")
 
 def normalize_pandoc_attrs(md_path: Path):
     """Normalize smart quotes, drop Pandoc attribute blocks, remove stray backslash

--- a/tests/test_mark_english_blocks.py
+++ b/tests/test_mark_english_blocks.py
@@ -27,16 +27,14 @@ def test_mark_english_blocks_emits_valid_colon_fences():
 
     rendered = mark_english_blocks(source)
 
-    assert ":::{div}" in rendered
+    assert ":::{container}" in rendered
     assert "::{{}}" not in rendered
     assert "::: {" not in rendered
 
     expected_paragraph = textwrap.dedent(
         """
-        :::{div}
+        :::{container}
         :class: en_quote
-        :dir: ltr
-
         An English paragraph that should be wrapped.
         :::
         """
@@ -45,10 +43,8 @@ def test_mark_english_blocks_emits_valid_colon_fences():
 
     expected_top_level = textwrap.dedent(
         """
-        :::{div}
+        :::{container}
         :class: en_quote
-        :dir: ltr
-
         > Energy is the only universal currency.
         > One of its many forms must be transformed to get anything done.
         :::
@@ -59,13 +55,12 @@ def test_mark_english_blocks_emits_valid_colon_fences():
     lines = rendered.splitlines()
     list_index = lines.index("- רשומה ברשימה")
     assert lines[list_index + 1].strip() == ""
-    assert lines[list_index + 2] == "  :::{div}"
+    assert lines[list_index + 2] == "  :::{container}"
     assert lines[list_index + 3] == "  :class: en_quote"
-    assert lines[list_index + 4] == "  :dir: ltr"
-    assert lines[list_index + 5].strip() == ""
-    assert lines[list_index + 6] == "  > This is an English quote inside a list."
-    assert lines[list_index + 7] == "  > It should keep its indentation."
-    assert lines[list_index + 8] == "  :::"
+    assert lines[list_index + 4].strip() == ""
+    assert lines[list_index + 5] == "  > This is an English quote inside a list."
+    assert lines[list_index + 6] == "  > It should keep its indentation."
+    assert lines[list_index + 7] == "  :::"
 
     assert "Another paragraph" in rendered
     assert "עם קצת Hebrew" in rendered


### PR DESCRIPTION
## Summary
- restyle Hebrew and English quote blocks so both render in the shaded panel and align correctly, and flip the sidebar/header controls back to the left-hand layout
- update the Markdown post-processing to emit MyST `container` fences for English quotes and drop orphaned footnote definitions during the pipeline
- refresh unit expectations for the quote wrapper output

## Testing
- `PYTHONDONTWRITEBYTECODE=1 pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d2f547ec6c832a82dfc42c81666abd